### PR TITLE
New sprite blendmodes inspired from MilkDrop 3: Multiply, Subtract, Invert, Cut-off, Darken and Vivid

### DIFF
--- a/resources/beatdrop_img.ini
+++ b/resources/beatdrop_img.ini
@@ -331,7 +331,7 @@ init_2=burn=0;
 
 [img14]
 img=textures\neon_infinity.mp4
-init_1=blendmode = 10; //unimplemented
+init_1=blendmode = 10;
 init_2=burn=0;
 init_3=timebeat = 0;
 code_1=timebeat += 1/fps;
@@ -366,7 +366,7 @@ init_3=sx = sy =.95;
 
 [img19]
 img=textures\astronaut_swim.mp4
-init_1=blendmode = 10; //unimplemented
+init_1=blendmode = 10;
 init_2=burn=0;
 
 [img20]
@@ -398,7 +398,7 @@ init_2=burn=0;
 
 [img24]
 img=textures\abstract_tunnel.webm
-init_1=blendmode = 10; //unimplemented
+init_1=blendmode = 10;
 init_2=burn=0;
 
 [img25]

--- a/vis_milk2/milkdropfs.cpp
+++ b/vis_milk2/milkdropfs.cpp
@@ -4744,6 +4744,17 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 			// printf("blendmode = %d : opacity = %f\n", blendmode, a);
 
 			// blendmode = 3; // for testing
+			// IMPORTANT: reset the render states that the extra blend modes (5-10) can leave
+			// behind (D3DRS_BLENDOP, D3DRS_ALPHATESTENABLE) BEFORE applying this sprite's own
+			// blendmode. Previously these were only reset once, AFTER the whole sprite loop
+			// finished (see bottom of DrawUserSprites), so a sprite using BLENDOP_MIN/MAX/
+			// REVSUBTRACT (Darken/Vivid/Subtract) or ALPHATESTENABLE (Invert) would silently
+			// leave that state active for every sprite drawn AFTER it in the same frame, even
+			// if the next sprite used a completely different (and non-overriding) blendmode.
+			// This is what caused blendmode 10 (Vivid) to 'stick' to later sprites.
+			lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+			lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+
 			switch(blendmode)
 			{
 			case 0:
@@ -4867,11 +4878,18 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 
 			case 7:
 				// invert
+				// A true |Src-Dest| 'difference' invert can't be expressed in a single
+				// fixed-function blend pass (no per-pixel abs() without a pixel shader).
+				// Exclusion is the closest single-pass equivalent and reads as an
+				// inversion/negative effect. We still alpha-test out fully-transparent
+				// texels (ref lowered from 0x80/50% to 0x01) so we don't chop off the
+				// sprite's soft/anti-aliased edges - the old 50% cutoff is likely why
+				// this mode looked shrunken/dim compared to MilkDrop3.
 				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
 				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
 				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_INVDESTCOLOR);
-				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ZERO);
-				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(a, a, a, a);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCCOLOR);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
 				break;
 
 			case 8:
@@ -4898,43 +4916,24 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MIN);
 				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
 				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
-				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
 				break;
 
 			case 10:
-				// Vivid (High Contrast / Glow)
-				// True "Vivid Light" is Color Dodge/Burn, which needs a divide the
-				// fixed-function D3D9 blender can't do, so this stays an approximation.
-				// Reverted to MAX-based Lighten (Dest = max(Src, Dest)): the previous
-				// DESTCOLOR-multiplicative attempt (Dest += Src*Dest) evaluates to a flat
-				// zero wherever the destination is black - i.e. the sprite completely
-				// vanished over any black/dark background (confirmed: spectrum-analyzer
-				// test showed nothing at all). MAX never has that failure mode, since
-				// max(Src, 0) = Src, so the sprite stays fully visible over black.
-				//
-				// Same texture-alpha fix as Darken above, but fading toward BLACK - the
-				// identity element for MAX (max(0,x)=x) - so transparent/faded texels
-				// correctly have no effect instead of forcing visible dark edges.
-				lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
-				lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
-				lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
-				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
-				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
-				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
-
-				lpDevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA_01(0, 0, 0, 1)); // black = MAX identity
-				lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_BLENDCURRENTALPHA);
-				lpDevice->SetTextureStageState(1, D3DTSS_COLORARG1, D3DTA_CURRENT);
-				lpDevice->SetTextureStageState(1, D3DTSS_COLORARG2, D3DTA_TFACTOR);
-				lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-				lpDevice->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
-				lpDevice->SetTextureStageState(2, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+				// Vivid (Screen-based glow): Result = Src + Dest - Src*Dest
+				// True Photoshop 'Vivid Light' conditionally dodges/burns per-pixel
+				// (branches on whether Src is above/below 0.5), which needs a pixel
+				// shader - not expressible as a fixed-function blend state. Screen is
+				// the closest single-pass formula with the same 'boosted brightness /
+				// glow' character, and unlike the old MAX/Lighten approach, it fades
+				// correctly to Dest (no effect) as 'a' drops to 0, since premultiplying
+				// Src by 'a' pushes DESTBLEND's (1-Src) factor toward 1.
 
 				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MAX);
+				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
 				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
-				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
-				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCCOLOR);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
 				break;
 			}
 
@@ -4970,36 +4969,37 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 				KillSprite(iSlot);
 			}
 
-			/*
-			Reset every piece of pipeline state that any blendmode case above might have
-			touched (D3DRS_BLENDOP, D3DRS_ALPHATESTENABLE, D3DRS_ALPHAREF/FUNC, the texture
-			stage states, and the colorkey pixel shader from case 4). This has to happen here,
-			once per sprite, INSIDE the loop - not just once after the whole for-loop ends.
-			Otherwise a sprite that doesn't set a particular state (e.g. a normal-blend sprite
-			doesn't touch D3DRS_BLENDOP) silently inherits whatever a previous sprite in the
-			same loop left behind (e.g. BLENDOP_MIN from a Darken sprite), so two sprites with
-			different blendmodes drawn back-to-back would incorrectly share state.
-			*/
-			lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
-			lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-			lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-
-			// Undo the pixel shader bound for a Spout sprite's blendmode-4 colorkey
-			// so it can't stay bound and affect the next sprite in the loop.
-			lpDevice->SetPixelShader(NULL);
-
-			// reset these to the standard safe mode:
-	        lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
-	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
-	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
-	        lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
-	        lpDevice->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	        lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1 );
             lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE );
             lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-            lpDevice->SetTextureStageState(2, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 		}
 	}
+
+	/*
+	Safety net: the REAL fix is now the per-sprite reset at the top of the blendmode switch
+	above (each sprite resets D3DRS_BLENDOP/D3DRS_ALPHATESTENABLE before applying its own
+	blendmode, so state from a previous sprite in the same frame can never leak forward).
+	This end-of-loop reset just makes sure nothing drawn AFTER DrawUserSprites() this frame
+	(borders, waveform, etc.) can inherit a leftover MIN/MAX/REVSUBTRACT/alpha-test state either.
+	*/
+	lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD); // <-
+	lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+	lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+
+	// Undo the pixel shader bound for a Spout sprite's blendmode-4 colorkey
+	// (see case 4 above) so it can't stay bound and affect anything drawn
+	// after this - every other sprite blendmode, and everything else in the
+	// renderer, expects the fixed-function pixel pipeline to be in control.
+	lpDevice->SetPixelShader(NULL);
+
+    // reset these to the standard safe mode:
+    lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+	lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
+	lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
+    lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1 );
+    lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE );
+    lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 }
 
 void CPlugin::UvToMathSpace(float u, float v, float* rad, float* ang)

--- a/vis_milk2/milkdropfs.cpp
+++ b/vis_milk2/milkdropfs.cpp
@@ -4867,20 +4867,11 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 
 			case 7:
 				// invert
-				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
-				//lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
-				//lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE);
-				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_TEXTURE);
-
-				lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
-				lpDevice->SetRenderState(D3DRS_ALPHAREF, 0x80); // Cutoff threshold
-				lpDevice->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
-
 				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
 				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
 				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_INVDESTCOLOR);
-				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
-				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ZERO);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(a, a, a, a);
 				break;
 
 			case 8:
@@ -4955,31 +4946,34 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 				KillSprite(iSlot);
 			}
 
+			/*
+			Reset every piece of pipeline state that any blendmode case above might have
+			touched (D3DRS_BLENDOP, D3DRS_ALPHATESTENABLE, D3DRS_ALPHAREF/FUNC, the texture
+			stage states, and the colorkey pixel shader from case 4). This has to happen here,
+			once per sprite, INSIDE the loop - not just once after the whole for-loop ends.
+			Otherwise a sprite that doesn't set a particular state (e.g. a normal-blend sprite
+			doesn't touch D3DRS_BLENDOP) silently inherits whatever a previous sprite in the
+			same loop left behind (e.g. BLENDOP_MIN from a Darken sprite), so two sprites with
+			different blendmodes drawn back-to-back would incorrectly share state.
+			*/
+			lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+			lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+			lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
+
+			// Undo the pixel shader bound for a Spout sprite's blendmode-4 colorkey
+			// so it can't stay bound and affect the next sprite in the loop.
+			lpDevice->SetPixelShader(NULL);
+
+			// reset these to the standard safe mode:
+	        lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
+	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
+	        lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	        lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1 );
             lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE );
             lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 		}
 	}
-
-	/*
-	It's obligatory to reset the blend option to add after invoking a sprite with any blend modes.
-	This should fix the affected visual (e.g min, max etc blend options affects the entire visual
-	incl. any sprites with different images).
-	*/
-	lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD); // <-
-	lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
-	lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
-
-	lpDevice->SetPixelShader(NULL);
-
-    // reset these to the standard safe mode:
-    lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
-	lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
-	lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
-    lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
-	lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1 );
-    lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE );
-    lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 }
 
 void CPlugin::UvToMathSpace(float u, float v, float* rad, float* ang)

--- a/vis_milk2/milkdropfs.cpp
+++ b/vis_milk2/milkdropfs.cpp
@@ -4903,14 +4903,38 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 
 			case 10:
 				// Vivid (High Contrast / Glow)
-				// Approximation: Dest = Src*Dest + Dest (Boosts brightness/contrast)
-				// Or Lighten: D3DBLENDOP_MAX
-				// Using DestColor + One creates a "Color Dodge" like vivid glow.
+				// True "Vivid Light" is Color Dodge/Burn, which needs a divide the
+				// fixed-function D3D9 blender can't do, so this stays an approximation.
+				// Reverted to MAX-based Lighten (Dest = max(Src, Dest)): the previous
+				// DESTCOLOR-multiplicative attempt (Dest += Src*Dest) evaluates to a flat
+				// zero wherever the destination is black - i.e. the sprite completely
+				// vanished over any black/dark background (confirmed: spectrum-analyzer
+				// test showed nothing at all). MAX never has that failure mode, since
+				// max(Src, 0) = Src, so the sprite stays fully visible over black.
+				//
+				// Same texture-alpha fix as Darken above, but fading toward BLACK - the
+				// identity element for MAX (max(0,x)=x) - so transparent/faded texels
+				// correctly have no effect instead of forcing visible dark edges.
+				lpDevice->SetTextureStageState(0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+				lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+				lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+
+				lpDevice->SetRenderState(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA_01(0, 0, 0, 1)); // black = MAX identity
+				lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_BLENDCURRENTALPHA);
+				lpDevice->SetTextureStageState(1, D3DTSS_COLORARG1, D3DTA_CURRENT);
+				lpDevice->SetTextureStageState(1, D3DTSS_COLORARG2, D3DTA_TFACTOR);
+				lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+				lpDevice->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
+				lpDevice->SetTextureStageState(2, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+
 				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
 				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MAX);
 				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
 				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
-				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
 				break;
 			}
 
@@ -4969,9 +4993,11 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_DIFFUSE);
 	        lpDevice->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_TEXTURE);
 	        lpDevice->SetTextureStageState(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
+	        lpDevice->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
 	        lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1 );
             lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE );
             lpDevice->SetTextureStageState(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+            lpDevice->SetTextureStageState(2, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 		}
 	}
 }

--- a/vis_milk2/milkdropfs.cpp
+++ b/vis_milk2/milkdropfs.cpp
@@ -4744,6 +4744,12 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 			// printf("blendmode = %d : opacity = %f\n", blendmode, a);
 
 			// blendmode = 3; // for testing
+
+			// A Spout colorkey uses a pixel shader, while every other sprite
+			// blend mode uses the fixed-function pipeline. Reset this per slot
+			// so a previous Spout sprite cannot affect the current sprite.
+			lpDevice->SetPixelShader(NULL);
+			
 			// IMPORTANT: reset the render states that the extra blend modes (5-10) can leave
 			// behind (D3DRS_BLENDOP, D3DRS_ALPHATESTENABLE) BEFORE applying this sprite's own
 			// blendmode. Previously these were only reset once, AFTER the whole sprite loop

--- a/vis_milk2/milkdropfs.cpp
+++ b/vis_milk2/milkdropfs.cpp
@@ -4631,7 +4631,7 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 			float repeatx = min(100.0f, max(0.01f, (float)(*m_texmgr.m_tex[iSlot].var_repeatx) ));
 			float repeaty = min(100.0f, max(0.01f, (float)(*m_texmgr.m_tex[iSlot].var_repeaty) ));
 
-			int blendmode = min(4, max(0, ((int)(*m_texmgr.m_tex[iSlot].var_blendmode))));
+			int blendmode = min(10, max(0, ((int)(*m_texmgr.m_tex[iSlot].var_blendmode))));
 			float r = min(1.0f, max(0.0f, ((float)(*m_texmgr.m_tex[iSlot].var_r))));
 			float g = min(1.0f, max(0.0f, ((float)(*m_texmgr.m_tex[iSlot].var_g))));
 			float b = min(1.0f, max(0.0f, ((float)(*m_texmgr.m_tex[iSlot].var_b))));
@@ -4847,6 +4847,80 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 					}
 				}
 				break;
+			case 5:
+				// multiply
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_DESTCOLOR);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ZERO);
+				// Modulate color allows for fading the multiplication effect
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
+				break;
+
+			case 6:
+				// subtract
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_REVSUBTRACT);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
+				break;
+
+			case 7:
+				// invert
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
+				//lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_MODULATE);
+				//lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_DIFFUSE);
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_TEXTURE);
+
+				lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_ALPHAREF, 0x80); // Cutoff threshold
+				lpDevice->SetRenderState(D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL);
+
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_INVDESTCOLOR);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
+				break;
+
+			case 8:
+				// Cut-off (Colorkeyed / Stencil)
+				// Punches a black hole where the sprite is opaque.
+				// Logic: Dest = 0*Src + Dest*(1-SrcAlpha)
+
+				// Setup Texture Stage for Colorkey
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
+				lpDevice->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_TEXTURE);
+
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ZERO);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
+
+				// Color doesn't affect the "cut", but Alpha does (so we pass 'a')
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r, g, b, a);
+				break;
+
+			case 9:
+				// Darken
+				// Dest = min(Src, Dest)
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MIN);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
+				break;
+
+			case 10:
+				// Vivid (High Contrast / Glow)
+				// Approximation: Dest = Src*Dest + Dest (Boosts brightness/contrast)
+				// Or Lighten: D3DBLENDOP_MAX
+				// Using DestColor + One creates a "Color Dodge" like vivid glow.
+				lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
+				lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_MAX);
+				lpDevice->SetRenderState(D3DRS_SRCBLEND, D3DBLEND_ONE);
+				lpDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_ONE);
+				for (k = 0; k < 4; k++) v3[k].Diffuse = D3DCOLOR_RGBA_01(r*a, g*a, b*a, a);
+				break;
 			}
 
 			lpDevice->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, (LPVOID)v3, sizeof(SPRITEVERTEX));
@@ -4887,6 +4961,13 @@ void CPlugin::DrawUserSprites()	// from system memory, to back buffer.
 		}
 	}
 
+	/*
+	It's obligatory to reset the blend option to add after invoking a sprite with any blend modes.
+	This should fix the affected visual (e.g min, max etc blend options affects the entire visual
+	incl. any sprites with different images).
+	*/
+	lpDevice->SetRenderState(D3DRS_BLENDOP, D3DBLENDOP_ADD); // <-
+	lpDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
 	lpDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE);
 
 	lpDevice->SetPixelShader(NULL);


### PR DESCRIPTION
BeatDrop now supports 6 new sprite blend modes that are inspired from MilkDrop 3.
You can now introduce blendmode = 5, 6, 7...10 in your image .ini file (`beatdrop_img.ini`). After invoking a sprite with new blend mode introduced, you may see some magic.

Here are some preview snapshots:
- Multiply (Multiplication)
<img width="auto" height="auto" alt="BeatDropMultiplySpriteBlendMode" src="https://github.com/user-attachments/assets/f210cb62-efc3-48e3-81ba-e0035f4374e4" />

- Subtract (Subtraction)
<img width="auto" height="auto" alt="BeatDropSubtractSpriteBlendMode" src="https://github.com/user-attachments/assets/a4076a5d-8c11-49e5-af34-1fcff9cee2d7" />

- Invert
<img width="auto" height="auto" alt="BeatDropInvertSpriteBlendMode" src="https://github.com/user-attachments/assets/28ecad9a-fb8f-4492-b83d-084c7bd3359d" />

- Cut-off
<img width="auto" height="auto" alt="BeatDropCut-offSpriteBlendMode" src="https://github.com/user-attachments/assets/1eb0a470-eb43-42b7-8fb4-8cc6f6d716ec" />

- Darken
<img width="auto" height="auto" alt="BeatDropDarkenSpriteBlendMode" src="https://github.com/user-attachments/assets/041da731-905f-4b34-acba-3ad0a6bc8859" />

- Vivid
<img width="auto" height="auto" alt="BeatDropVividSpriteBlendMode" src="https://github.com/user-attachments/assets/17167e8b-fa3a-4c97-9e90-06fefda522cf" />

NOTE: Some of the sprites are the same (or 1:1) as MilkDrop 3, some of them aren't and what it fits for me.
A SkiGyimes bob track landscape picture were taken by me at autumn 2024 using Z Fold4 because I loved this place very much. I've started this experience at 2020 and I've really enjoyed it.